### PR TITLE
Update plugin to Capacitor 3

### DIFF
--- a/ByteowlsCapacitorSms.podspec
+++ b/ByteowlsCapacitorSms.podspec
@@ -10,9 +10,9 @@ require 'json'
     s.license = package['license']
     s.homepage = package['homepage']
     s.author = package['author']
-    s.ios.deployment_target  = '11.0'
+    s.ios.deployment_target  = '12.0'
     s.dependency 'Capacitor'
     s.source = { :git => 'https://github.com/moberwasserlechner/capacitor-sms', :tag => s.version.to_s }
     s.source_files = 'ios/ByteowlsCapacitorSms/Source/*.{swift,h,m}'
-    s.swift_version = '5.0'
+    s.swift_version = '5.1'
   end

--- a/README.md
+++ b/README.md
@@ -11,32 +11,16 @@ Plugin for sending short messages using the device's SMS app.
 
 `npm i @byteowls/capacitor-sms`
 
-Minimum Capacitor version is **2.0.0**
+Minimum Capacitor version is **3.0.0**
+
+### Capacitor 2.x
+`npm i @byteowls/capacitor-sms@2`
 
 ## Configuration
 
 This example shows the common process of configuring this plugin.
 
 Although it was taken from a Angular 6 application, it should work in other frameworks as well.
-
-### Register plugin
-
-Find the init component of your app, which is in Angular `app.component.ts` and register this plugin by
-
-```
-import {registerWebPlugin} from "@capacitor/core";
-import {SmsManager} from '@byteowls/capacitor-sms';
-
-@Component()
-export class AppComponent implements OnInit {
-
-    ngOnInit() {
-        console.log("Register custom capacitor plugins");
-        registerWebPlugin(SmsManager);
-        // other stuff
-    }
-}
-```
 
 ### Use it
 
@@ -81,17 +65,17 @@ here because the plugin is much easier to maintain if only one feature is suppor
 **Register the plugin** in `com.companyname.appname.MainActivity#onCreate`
 
 ```
-    @Override
-    public void onCreate(Bundle savedInstanceState) {
-        super.onCreate(savedInstanceState);
-
-        List<Class<? extends Plugin>> additionalPlugins = new ArrayList<>();
-        // Additional plugins you've installed go here
-        // Ex: additionalPlugins.add(TotallyAwesomePlugin.class);
-        additionalPlugins.add(com.byteowls.capacitor.sms.SmsManagerPlugin.class);
-
-        // Initializes the Bridge
-        this.init(savedInstanceState, additionalPlugins);
+    ...
+    import com.byteowls.capacitor.sms.SmsManagerPlugin;
+    ...
+    public class MainActivity extends BridgeActivity {
+        @Override
+        public void onCreate(Bundle savedInstanceState) {
+            super.onCreate(savedInstanceState);
+            ...
+            registerPlugin(SmsManagerPlugin.class);
+            ...
+        }
     }
 ```
 

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,20 +1,27 @@
+ext {
+    junitVersion = project.hasProperty('junitVersion') ? rootProject.ext.junitVersion : '4.13.1'
+    androidxAppCompatVersion = project.hasProperty('androidxAppCompatVersion') ? rootProject.ext.androidxAppCompatVersion : '1.2.0'
+    androidxJunitVersion = project.hasProperty('androidxJunitVersion') ? rootProject.ext.androidxJunitVersion : '1.1.2'
+    androidxEspressoCoreVersion = project.hasProperty('androidxEspressoCoreVersion') ? rootProject.ext.androidxEspressoCoreVersion : '3.3.0'
+}
+
 buildscript {
     repositories {
         google()
-        jcenter()
+        mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.4.1'
+        classpath 'com.android.tools.build:gradle:4.2.1'
     }
 }
 
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 28
+    compileSdkVersion project.hasProperty('compileSdkVersion') ? rootProject.ext.compileSdkVersion : 30
     defaultConfig {
-        minSdkVersion 21
-        targetSdkVersion 28
+        minSdkVersion project.hasProperty('minSdkVersion') ? rootProject.ext.minSdkVersion : 21
+        targetSdkVersion project.hasProperty('targetSdkVersion') ? rootProject.ext.targetSdkVersion : 30
         versionCode 2
         versionName "2.0.0"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
@@ -36,12 +43,14 @@ android {
 
 repositories {
     google()
+    jcenter()
     mavenCentral()
 }
 
 dependencies {
     implementation project(':capacitor-android')
     testImplementation 'junit:junit:4.12'
+    implementation "androidx.appcompat:appcompat:$androidxAppCompatVersion"
     androidTestImplementation 'androidx.test.ext:junit:1.1.1'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.1.0'
 }

--- a/android/src/main/java/com/byteowls/capacitor/sms/SmsManagerPlugin.java
+++ b/android/src/main/java/com/byteowls/capacitor/sms/SmsManagerPlugin.java
@@ -3,18 +3,20 @@ package com.byteowls.capacitor.sms;
 import android.content.Intent;
 import android.net.Uri;
 import com.getcapacitor.JSArray;
-import com.getcapacitor.NativePlugin;
+import com.getcapacitor.annotation.CapacitorPlugin;
 import com.getcapacitor.Plugin;
 import com.getcapacitor.PluginCall;
 import com.getcapacitor.PluginMethod;
 import org.json.JSONException;
+import androidx.activity.result.ActivityResult;
+import com.getcapacitor.annotation.ActivityCallback;
 
 import java.util.List;
 
-@NativePlugin(requestCodes = { SmsManagerPlugin.SMS_INTENT_REQUEST_CODE }, name = "SmsManager")
+@CapacitorPlugin(
+    name = "SmsManager"
+)
 public class SmsManagerPlugin extends Plugin {
-
-    static final int SMS_INTENT_REQUEST_CODE = 2311;
     private static final String ERR_SERVICE_NOTFOUND = "ERR_SERVICE_NOTFOUND";
     private static final String ERR_NO_NUMBERS = "ERR_NO_NUMBERS";
     private static final String ERR_NO_TEXT = "ERR_NO_TEXT";
@@ -23,7 +25,6 @@ public class SmsManagerPlugin extends Plugin {
 
     @PluginMethod()
     public void send(final PluginCall call) {
-        saveCall(call);
         sendSms(call);
     }
 
@@ -59,20 +60,16 @@ public class SmsManagerPlugin extends Plugin {
         smsIntent.setData(Uri.parse("smsto:" + Uri.encode(phoneNumber)));
 
         if (smsIntent.resolveActivity(getContext().getPackageManager()) != null) {
-            startActivityForResult(call, smsIntent, SMS_INTENT_REQUEST_CODE);
+            startActivityForResult(call, smsIntent, "onSmsRequestResult");
         } else {
             call.reject(ERR_SERVICE_NOTFOUND);
         }
 
     }
 
-    @Override
-    protected void handleOnActivityResult(int requestCode, int resultCode, Intent data) {
-        if (requestCode == SMS_INTENT_REQUEST_CODE) {
-            PluginCall savedCall = getSavedCall();
-            savedCall.resolve();
-        }
-        super.handleOnActivityResult(requestCode, resultCode, data);
+    @ActivityCallback
+    private void onSmsRequestResult(PluginCall call, ActivityResult result) {
+        call.resolve();
     }
 
     private String getJoinedNumbers(List<String>numbers, String separator) {

--- a/ios/ByteowlsCapacitorSms/Podfile
+++ b/ios/ByteowlsCapacitorSms/Podfile
@@ -1,5 +1,5 @@
 # Uncomment the next line to define a global platform for your project
-platform :ios, '11.0'
+platform :ios, '12.0'
 
 target 'ByteowlsCapacitorSms' do
   # Comment the next line if you're not using Swift and don't want to use dynamic frameworks

--- a/ios/ByteowlsCapacitorSms/Source/ByteowlsCapacitorSms.swift
+++ b/ios/ByteowlsCapacitorSms/Source/ByteowlsCapacitorSms.swift
@@ -6,21 +6,21 @@ typealias JSObject = [String:Any]
 
 @objc(SmsManagerPlugin)
 public class SmsManagerPlugin: CAPPlugin, MFMessageComposeViewControllerDelegate {
-    
+
     let PARAM_NUMBERS = "numbers"
     let PARAM_TEXT = "text"
-    
+
     var pluginCall: CAPPluginCall?
-    
+
     public func messageComposeViewController(_ controller: MFMessageComposeViewController, didFinishWith result: MessageComposeResult) {
-       
+
         switch (result.rawValue) {
         case MessageComposeResult.cancelled.rawValue:
             self.pluginCall!.reject("SEND_CANCELLED")
         case MessageComposeResult.failed.rawValue:
             self.pluginCall!.reject("ERR_SEND_FAILED")
         case MessageComposeResult.sent.rawValue:
-            self.pluginCall!.success()
+            self.pluginCall!.resolve()
         default:
             self.pluginCall!.reject("ERR_SEND_UNKNOWN_STATE")
         }
@@ -37,12 +37,12 @@ public class SmsManagerPlugin: CAPPlugin, MFMessageComposeViewControllerDelegate
             call.reject("ERR_NO_TEXT")
             return
         }
-        
+
         if !MFMessageComposeViewController.canSendText() {
             call.reject("ERR_SERVICE_NOTFOUND")
             return
         }
-        
+
         let composeVC = MFMessageComposeViewController()
         composeVC.messageComposeDelegate = self
         // Configure the fields of the interface.
@@ -51,7 +51,7 @@ public class SmsManagerPlugin: CAPPlugin, MFMessageComposeViewControllerDelegate
         // Present the view controller modally.
         DispatchQueue.main.async {
             // Update UI
-            self.bridge.viewController.present(composeVC, animated: true, completion: nil);
+            self.bridge?.viewController?.present(composeVC, animated: true, completion: nil);
         }
     }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,40 +1,104 @@
 {
     "name": "@byteowls/capacitor-sms",
     "version": "2.0.0",
-    "lockfileVersion": 1,
+    "lockfileVersion": 2,
     "requires": true,
-    "dependencies": {
-        "@capacitor/android": {
+    "packages": {
+        "": {
+            "name": "@byteowls/capacitor-sms",
             "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/@capacitor/android/-/android-2.0.0.tgz",
-            "integrity": "sha512-ATMKHFSdBMcP5iqNeVwpyzAvXQ44bFmCEjmGuTqr9VCooUvwLpekiLedwWXldA94jJ0TbyGQZJeyLq++7f+kLg==",
+            "license": "MIT",
+            "devDependencies": {
+                "@capacitor/android": "3.0.0",
+                "@capacitor/core": "3.0.0",
+                "@capacitor/ios": "3.0.0",
+                "typescript": "^4.0.3"
+            },
+            "peerDependencies": {
+                "@capacitor/core": "^3.0.0"
+            }
+        },
+        "node_modules/@capacitor/android": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/@capacitor/android/-/android-3.0.0.tgz",
+            "integrity": "sha512-qyvI3LzfGvVnSK7Dw3dXXLSJjfj816EfWHiyGzV4Rg5r2XkvPa8IqjHT3lmyxwNJjGdHl3TTn9Q6YvM6XD70cQ==",
+            "dev": true,
+            "peerDependencies": {
+                "@capacitor/core": "~3.0.0"
+            }
+        },
+        "node_modules/@capacitor/core": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/@capacitor/core/-/core-3.0.0.tgz",
+            "integrity": "sha512-JmKE6QEayo8MqWcApwMP5YFimpVb2mcIEHBwgP/P9nSAOxOcbdpJyd9HhBt5pzZAE1MBngPADWWwZLrdNSjCnA==",
+            "dev": true,
+            "dependencies": {
+                "tslib": "^2.1.0"
+            }
+        },
+        "node_modules/@capacitor/ios": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/@capacitor/ios/-/ios-3.0.0.tgz",
+            "integrity": "sha512-EvWW86hQqmoY0qFV1LJyZujlgfEgl4iEUJVhCv84mshMyS2bXZu5Ip4yuKtJBDsKmTWyA7rfcAnPMEnUfQ6bkw==",
+            "dev": true,
+            "peerDependencies": {
+                "@capacitor/core": "~3.0.0"
+            }
+        },
+        "node_modules/tslib": {
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.0.tgz",
+            "integrity": "sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg==",
             "dev": true
         },
+        "node_modules/typescript": {
+            "version": "4.3.5",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.3.5.tgz",
+            "integrity": "sha512-DqQgihaQ9cUrskJo9kIyW/+g0Vxsk8cDtZ52a3NGh0YNTfpUSArXSohyUGnvbPazEPLu398C0UxmKSOrPumUzA==",
+            "dev": true,
+            "bin": {
+                "tsc": "bin/tsc",
+                "tsserver": "bin/tsserver"
+            },
+            "engines": {
+                "node": ">=4.2.0"
+            }
+        }
+    },
+    "dependencies": {
+        "@capacitor/android": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/@capacitor/android/-/android-3.0.0.tgz",
+            "integrity": "sha512-qyvI3LzfGvVnSK7Dw3dXXLSJjfj816EfWHiyGzV4Rg5r2XkvPa8IqjHT3lmyxwNJjGdHl3TTn9Q6YvM6XD70cQ==",
+            "dev": true,
+            "requires": {}
+        },
         "@capacitor/core": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/@capacitor/core/-/core-2.0.0.tgz",
-            "integrity": "sha512-u21az92VjHG14pHt0v33s0LwE19ICoUhrMdJdc5F/fHLEw1pBsJvyuK9C11SmDyv1QJjwmPvq6Rh0+BIRGAgLQ==",
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/@capacitor/core/-/core-3.0.0.tgz",
+            "integrity": "sha512-JmKE6QEayo8MqWcApwMP5YFimpVb2mcIEHBwgP/P9nSAOxOcbdpJyd9HhBt5pzZAE1MBngPADWWwZLrdNSjCnA==",
             "dev": true,
             "requires": {
-                "tslib": "^1.9.0"
+                "tslib": "^2.1.0"
             }
         },
         "@capacitor/ios": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/@capacitor/ios/-/ios-2.0.0.tgz",
-            "integrity": "sha512-XvTyVbJC7iRvWvqUfSM0yCmpKIO2NXHAA5OfkjA/legsd/YJZKUAPXaJujWermpYTSHkE4jZYOOjzoUZ+caolA==",
-            "dev": true
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/@capacitor/ios/-/ios-3.0.0.tgz",
+            "integrity": "sha512-EvWW86hQqmoY0qFV1LJyZujlgfEgl4iEUJVhCv84mshMyS2bXZu5Ip4yuKtJBDsKmTWyA7rfcAnPMEnUfQ6bkw==",
+            "dev": true,
+            "requires": {}
         },
         "tslib": {
-            "version": "1.11.1",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.11.1.tgz",
-            "integrity": "sha512-aZW88SY8kQbU7gpV19lN24LtXh/yD4ZZg6qieAJDDg+YBsJcSmLGK9QpnUjAKVG/xefmvJGd1WUmfpT/g6AJGA==",
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.0.tgz",
+            "integrity": "sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg==",
             "dev": true
         },
         "typescript": {
-            "version": "3.8.3",
-            "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.8.3.tgz",
-            "integrity": "sha512-MYlEfn5VrLNsgudQTVJeNaQFUAI7DkhnOjdpAp4T+ku1TfQClewlbSuTVHiA+8skNBgaf02TL/kLOvig4y3G8w==",
+            "version": "4.3.5",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.3.5.tgz",
+            "integrity": "sha512-DqQgihaQ9cUrskJo9kIyW/+g0Vxsk8cDtZ52a3NGh0YNTfpUSArXSohyUGnvbPazEPLu398C0UxmKSOrPumUzA==",
             "dev": true
         }
     }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@byteowls/capacitor-sms",
-    "version": "2.0.0",
+    "version": "3.0.0",
     "description": "Capacitor SMS plugin",
     "author": "Michael Oberwasserlechner",
     "homepage": "https://github.com/moberwasserlechner/capacitor-sms",

--- a/package.json
+++ b/package.json
@@ -45,12 +45,12 @@
         "access": "public"
     },
     "peerDependencies": {
-        "@capacitor/core": "^2.0.0"
+        "@capacitor/core": "^3.0.0"
     },
     "devDependencies": {
-        "@capacitor/core": "2.0.0",
-        "@capacitor/ios": "2.0.0",
-        "@capacitor/android": "2.0.0",
-        "typescript": "^3.5.3"
+        "@capacitor/core": "3.0.0",
+        "@capacitor/ios": "3.0.0",
+        "@capacitor/android": "3.0.0",
+        "typescript": "^4.0.3"
     }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,2 +1,11 @@
+import { registerPlugin } from '@capacitor/core';
+import { SmsManagerPluginWeb } from './web';
+
+const SmsManager = registerPlugin<SmsManagerPluginWeb>('SmsManager', {
+    web: () => import('./web').then(m => new m.SmsManagerPluginWeb()),
+});
+
+
+
+export { SmsManager };
 export * from './definitions';
-export * from './web';

--- a/src/web.ts
+++ b/src/web.ts
@@ -1,4 +1,4 @@
-import {WebPlugin} from '@capacitor/core';
+import { WebPlugin } from '@capacitor/core';
 import {SmsManagerPlugin, SmsSendOptions} from "./definitions";
 
 export class SmsManagerPluginWeb extends WebPlugin implements SmsManagerPlugin {
@@ -19,11 +19,3 @@ export class SmsManagerPluginWeb extends WebPlugin implements SmsManagerPlugin {
     }
 
 }
-
-const SmsManager = new SmsManagerPluginWeb();
-
-export { SmsManager };
-
-// this does not work for angular. You need to register the plugin in app.component.ts again.
-import { registerWebPlugin } from '@capacitor/core';
-registerWebPlugin(SmsManager);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,16 +5,16 @@
         "experimentalDecorators": true,
         "lib": [
             "dom",
-            "es2015"
+            "es2017"
         ],
-        "module": "es2015",
+        "module": "esnext",
         "moduleResolution": "node",
         "noImplicitAny": true,
         "noUnusedLocals": false,
         "noUnusedParameters": false,
         "outDir": "dist/esm",
         "sourceMap": true,
-        "target": "es2015"
+        "target": "es2017"
     },
     "files": [
         "src/index.ts"


### PR DESCRIPTION
Lets add support for Capacitor 3
- Updated android and iOS integrations
- Updated web (still not supported but no need to initialize the plugin in project code)
- Updated readme and version bumped to 3.0.0

Until this PR is merged it is possible to use it straight from github:
```bash
npm install https://github.com/chrum/capacitor-sms --save
```