### PR TITLE
feat(android): return SEND_CANCELLED if user cancels

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ export class SmsExampleComponent implements OnInit {
 
 ### Error Codes
 
-* SEND_CANCELLED ... User cancelled or closed the SMS app. (ios only)
+* SEND_CANCELLED ... User cancelled or closed the SMS app.
 * ERR_SEND_FAILED ... The SMS app returned that sending the message to the recipients failed. (ios only)
 * ERR_SEND_UNKNOWN_STATE ... The SMS app returned a unknown state. There is nothing I can do to clarify the error. (ios only)
 * ERR_PLATFORM_NOT_SUPPORTED ... Sending SMS on the web is not supported.

--- a/android/src/main/java/com/byteowls/capacitor/sms/SmsManagerPlugin.java
+++ b/android/src/main/java/com/byteowls/capacitor/sms/SmsManagerPlugin.java
@@ -1,5 +1,6 @@
 package com.byteowls.capacitor.sms;
 
+import android.app.Activity;
 import android.content.Intent;
 import android.net.Uri;
 import com.getcapacitor.JSArray;
@@ -69,7 +70,11 @@ public class SmsManagerPlugin extends Plugin {
 
     @ActivityCallback
     private void onSmsRequestResult(PluginCall call, ActivityResult result) {
-        call.resolve();
+        if (result.getResultCode() == Activity.RESULT_CANCELED) {
+            call.reject("SEND_CANCELLED");
+        } else {
+            call.resolve();
+        }
     }
 
     private String getJoinedNumbers(List<String>numbers, String separator) {

--- a/android/src/main/java/com/byteowls/capacitor/sms/SmsManagerPlugin.java
+++ b/android/src/main/java/com/byteowls/capacitor/sms/SmsManagerPlugin.java
@@ -22,6 +22,7 @@ public class SmsManagerPlugin extends Plugin {
     private static final String ERR_SERVICE_NOTFOUND = "ERR_SERVICE_NOTFOUND";
     private static final String ERR_NO_NUMBERS = "ERR_NO_NUMBERS";
     private static final String ERR_NO_TEXT = "ERR_NO_TEXT";
+    private static final String SEND_CANCELLED = "SEND_CANCELLED";
 
     public SmsManagerPlugin() {}
 
@@ -71,7 +72,7 @@ public class SmsManagerPlugin extends Plugin {
     @ActivityCallback
     private void onSmsRequestResult(PluginCall call, ActivityResult result) {
         if (result.getResultCode() == Activity.RESULT_CANCELED) {
-            call.reject("SEND_CANCELLED");
+            call.reject(SEND_CANCELLED);
         } else {
             call.resolve();
         }


### PR DESCRIPTION
On Android the call was always succeeding even if the intent was canceled